### PR TITLE
Set updated_in according to standard Magento

### DIFF
--- a/src/Observers/EeCategoryObserver.php
+++ b/src/Observers/EeCategoryObserver.php
@@ -57,7 +57,7 @@ class EeCategoryObserver extends CategoryObserver
         $additionalAttr = array(
             MemberNames::ENTITY_ID  => $this->nextIdentifier(),
             MemberNames::CREATED_IN => 1,
-            MemberNames::UPDATED_IN => strtotime(SqlConstants::MAX_UNIXTIMESTAMP)
+            MemberNames::UPDATED_IN => SqlConstants::MAX_UNIXTIMESTAMP
         );
 
         // merge and return the attributes

--- a/src/Observers/EeCategoryObserver.php
+++ b/src/Observers/EeCategoryObserver.php
@@ -22,6 +22,7 @@ namespace TechDivision\Import\Category\Ee\Observers;
 
 use TechDivision\Import\Category\Ee\Utils\MemberNames;
 use TechDivision\Import\Category\Observers\CategoryObserver;
+use TechDivision\Import\Ee\Utils\SqlConstants;
 
 /**
  * Observer that create's the category itself for the Magento 2 EE edition.
@@ -56,7 +57,7 @@ class EeCategoryObserver extends CategoryObserver
         $additionalAttr = array(
             MemberNames::ENTITY_ID  => $this->nextIdentifier(),
             MemberNames::CREATED_IN => 1,
-            MemberNames::UPDATED_IN => strtotime('+20 years')
+            MemberNames::UPDATED_IN => strtotime(SqlConstants::MAX_UNIXTIMESTAMP)
         );
 
         // merge and return the attributes

--- a/src/Observers/EeCategoryUpdateObserver.php
+++ b/src/Observers/EeCategoryUpdateObserver.php
@@ -20,6 +20,7 @@
 
 namespace TechDivision\Import\Category\Ee\Observers;
 
+use TechDivision\Import\Ee\Utils\SqlConstants;
 use TechDivision\Import\Utils\EntityStatus;
 use TechDivision\Import\Category\Ee\Utils\MemberNames;
 use TechDivision\Import\Category\Observers\CategoryUpdateObserver;
@@ -62,7 +63,7 @@ class EeCategoryUpdateObserver extends CategoryUpdateObserver
             $additionalAttr = array(
                 MemberNames::ENTITY_ID  => $this->nextIdentifier(),
                 MemberNames::CREATED_IN => 1,
-                MemberNames::UPDATED_IN => strtotime('+20 years')
+                MemberNames::UPDATED_IN => strtotime(SqlConstants::MAX_UNIXTIMESTAMP)
             );
 
             // merge and return the attributes

--- a/src/Observers/EeCategoryUpdateObserver.php
+++ b/src/Observers/EeCategoryUpdateObserver.php
@@ -63,7 +63,7 @@ class EeCategoryUpdateObserver extends CategoryUpdateObserver
             $additionalAttr = array(
                 MemberNames::ENTITY_ID  => $this->nextIdentifier(),
                 MemberNames::CREATED_IN => 1,
-                MemberNames::UPDATED_IN => strtotime(SqlConstants::MAX_UNIXTIMESTAMP)
+                MemberNames::UPDATED_IN => SqlConstants::MAX_UNIXTIMESTAMP
             );
 
             // merge and return the attributes


### PR DESCRIPTION
Currently Magento evaluates the timestamp in only in PHP context. This is a precaution to avoid unexpected behaviour shoud the timestamp sometime be evaluated in SQL.